### PR TITLE
feat(http): configurable timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Configurable environment variables for Bustinel. Values labelled as required mus
 | `METADATA_URL`              | The URL of the GTFS metadata file                                | `nil`         | ✅       |
 | `METADATA_REFRESH_INTERVAL` | The interval at which to refresh the metadata in CRON format     | `0 * * * *`   | ❌       |
 | `CONTACT`                   | A contactable email address for complaints.                      | `nil`         | ✅       |
+| `TIMEOUT`                   | The timeout duration for requests in seconds                      | `30`          | ❌       |
 
 ## 🏆 Contributors
 

--- a/internal/helpers/config.go
+++ b/internal/helpers/config.go
@@ -4,7 +4,9 @@ package helpers
 import (
 	"os"
 	"regexp"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/NotAussie/bustinel/internal/models"
 	"go.uber.org/zap"
@@ -81,6 +83,15 @@ func LoadConfig(logger *zap.Logger) models.Config {
 				return ""
 			}
 			return ""
+		}(),
+		Timeout: func() int64 {
+			if v := os.Getenv("TIMEOUT"); v != "" {
+				if parsed, err := strconv.Atoi(v); err == nil {
+					return int64(parsed)
+				}
+				logger.Fatal("Invalid TIMEOUT value", zap.String("value", v))
+			}
+			return int64(30 * time.Second)
 		}(),
 	}
 }

--- a/internal/models/config.go
+++ b/internal/models/config.go
@@ -13,4 +13,5 @@ type Config struct {
 	Authorisation           *string
 	AuthorisationHeader     string
 	Contact                 string
+	Timeout                 int64 // in seconds
 }

--- a/internal/services/realtime.go
+++ b/internal/services/realtime.go
@@ -16,7 +16,7 @@ import (
 
 // Retrieves real-time vehicle positions from a GTFS feed and stores new trip records in the database.
 func FetchVehiclePositions(ctx context.Context, app *helpers.App) error {
-	client := &http.Client{Timeout: 30 * time.Second}
+	client := &http.Client{Timeout: time.Duration(app.Config.Timeout)}
 
 	// Create HTTP request
 	req, err := http.NewRequestWithContext(ctx, "GET", app.Config.FeedURL, nil)

--- a/internal/services/static.go
+++ b/internal/services/static.go
@@ -14,7 +14,7 @@ import (
 
 // Retrieves GTFS static data and stores the parsed data into the global app storage
 func FetchStaticData(ctx context.Context, app *helpers.App) error {
-	client := &http.Client{Timeout: 30 * time.Second}
+	client := &http.Client{Timeout: time.Duration(app.Config.Timeout)}
 
 	app.Logger.Info("Fetching static data", zap.String("url", app.Config.MetadataURL))
 


### PR DESCRIPTION
Allows for a configurable timeout for requests (useful for static files that are MASSIVE)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced configurable request timeout via the TIMEOUT environment variable. Defaults to 30 seconds if unset. Applies to both real-time and static data fetches, allowing users to adjust behavior for different network conditions.

* **Documentation**
  * Updated README to document the TIMEOUT environment variable, including default value and usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->